### PR TITLE
Use top level namespace for Rails::Railtie class

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,6 @@
 name: Run RSpec tests
 on: [push, pull_request]
-jobs: 
+jobs:
   test:
     runs-on: ubuntu-latest
     env:
@@ -8,10 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.81.0
+        uses: ruby/setup-ruby@v1.190.0
         with:
           # Not needed with a .ruby-version file
-          ruby-version: 2.7
+          ruby-version: 3.3.0
           bundler-cache: true
       - name: Run tests
         run: |

--- a/lib/dotenv/beefy/railtie.rb
+++ b/lib/dotenv/beefy/railtie.rb
@@ -3,7 +3,7 @@ require 'rbconfig'
 
 module Dotenv
   module Beefy
-    class Railtie < Rails::Railtie
+    class Railtie < ::Rails::Railtie
       config.before_configuration { load_environments }
 
       # Load environment dotfiles in the following order (e.g. if in "test" environment on "darwin")
@@ -13,27 +13,27 @@ module Dotenv
       # 4. .env.test
       # 5. .env.darwin
       # 6. .env
-      # 
+      #
       # The order matters, because the files loaded first will "lock in" the value for that ENV var.
       # Dotenv.load memoizes each ENV value, and if the value is set, it cannot be updated later.
       # If you want to update ENV values as new values come in, you need to use Dotenv.overload(*files)
       def load_environments
         files = []
-        
-        environments.each do |env| 
+
+        environments.each do |env|
           files << ".env.#{env}.local"
         end
 
         # This is a dotenv-rails convention to ignore `.env.local` in a test environment
         # @see https://github.com/bkeepers/dotenv/blob/c237d6d6291c898d8affb290b510c7aac49aed71/lib/dotenv/rails.rb#L66-L73
-        files << '.env.local' unless Rails.env.test? 
-        
-        environments.each do |env| 
+        files << '.env.local' unless Rails.env.test?
+
+        environments.each do |env|
           files << ".env.#{env}"
         end
 
         files << '.env'
-        
+
         Dotenv.load(*files)
       end
 


### PR DESCRIPTION
Updated a Rails app to 7.2. When I tried to run rspec, I got the following error. 

```
An error occurred while loading rails_helper.
Failure/Error: require_relative '../config/environment'

NameError:
  uninitialized constant Dotenv::Rails::Railtie
# ./vendor/bundle/ruby/3.3.0/gems/dotenv-beefy-0.2.0/lib/dotenv/beefy/railtie.rb:6:in `<module:Beefy>'
# ./vendor/bundle/ruby/3.3.0/gems/dotenv-beefy-0.2.0/lib/dotenv/beefy/railtie.rb:5:in `<module:Dotenv>'
# ./vendor/bundle/ruby/3.3.0/gems/dotenv-beefy-0.2.0/lib/dotenv/beefy/railtie.rb:4:in `<main>'
# ./vendor/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.17/lib/zeitwerk/kernel.rb:34:in `require'
# ./vendor/bundle/ruby/3.3.0/gems/dotenv-beefy-0.2.0/lib/dotenv/beefy.rb:2:in `<main>'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.17/lib/zeitwerk/kernel.rb:34:in `require'
# /usr/local/bundle/gems/bundler-2.5.17/lib/bundler.rb:212:in `require'
# ./config/application.rb:21:in `<top (required)>'
# ./config/environment.rb:4:in `require_relative'
# ./config/environment.rb:4:in `<top (required)>'
# ./spec/rails_helper.rb:6:in `require_relative'
# ./spec/rails_helper.rb:6:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- dotenv-beefy
#   ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.17/lib/zeitwerk/kernel.rb:34:in `require'
```

Updated the `run_tests` workflow to use recent versions of Ruby and setup-ruby.
And also looks like my editor cleaned up some whitespace.